### PR TITLE
Add packet insertion feature with 'a' key

### DIFF
--- a/auto_commit.sh
+++ b/auto_commit.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Auto-commit script for AI-assisted development
+# This script monitors changes and commits them automatically
+
+# Function to commit changes
+commit_changes() {
+    local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+    local message="Auto-commit: AI-assisted changes at $timestamp"
+    
+    # Add all changes
+    git add .
+    
+    # Check if there are changes to commit
+    if ! git diff-index --quiet HEAD --; then
+        git commit -m "$message"
+        echo "✅ Committed changes: $message"
+    else
+        echo "ℹ️  No changes to commit"
+    fi
+}
+
+# Function to monitor file changes
+monitor_changes() {
+    echo "🔍 Starting file change monitoring..."
+    echo "Press Ctrl+C to stop monitoring"
+    
+    # Use fswatch to monitor file changes (macOS)
+    if command -v fswatch >/dev/null 2>&1; then
+        fswatch -o . | while read f; do
+            echo "📝 Detected file change, committing..."
+            commit_changes
+        done
+    else
+        echo "⚠️  fswatch not found. Install with: brew install fswatch"
+        echo "📝 Committing current changes..."
+        commit_changes
+    fi
+}
+
+# Main execution
+echo "🤖 Auto-commit script for AI-assisted development"
+echo "Branch: $(git branch --show-current)"
+
+# Check if we're in a git repository
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    echo "❌ Error: Not in a git repository"
+    exit 1
+fi
+
+# Check if we have uncommitted changes
+if ! git diff-index --quiet HEAD --; then
+    echo "📝 Found uncommitted changes, committing them first..."
+    commit_changes
+fi
+
+# Start monitoring
+monitor_changes 

--- a/pcap_hex_editor/main.py
+++ b/pcap_hex_editor/main.py
@@ -153,7 +153,7 @@ class PcapHexEditorApp(App):
         self.save_filename = f"edited_{self.pcap_filename}"
 
     def compose(self) -> ComposeResult:
-        self.packet_list_panel = PacketListPanel("Packet List", self.on_packet_select, id="panel-list")
+        self.packet_list_panel = PacketListPanel("Packet List", self.on_packet_select, self.on_packet_add, id="panel-list")
         self.hex_editor_panel = HexEditorPanel("Hex View", on_edit_callback=self.on_hex_edit, id="panel-hex")
         self.scapy_command_panel = ScapyCommandPanel("Edit Scapy Command", on_edit_callback=self.on_command_edit, id="panel-command")
         self.dissection_panel = DissectionPanel("Dissection", id="panel-dissect")
@@ -207,6 +207,16 @@ class PcapHexEditorApp(App):
         self.hex_editor_panel.set_packet(pkt)
         self.dissection_panel.set_packet(pkt)
         self.scapy_command_panel.set_packet(pkt)
+
+    def on_packet_add(self, index, new_packet):
+        """Handle new packet addition."""
+        self.selected_index = index
+        self.status_message = f"Added new packet at index {index}"
+        # Update all panels with the new packet
+        self.hex_editor_panel.set_packet(new_packet)
+        self.dissection_panel.set_packet(new_packet)
+        self.scapy_command_panel.set_packet(new_packet)
+        self.refresh()
 
     def on_hex_edit(self, new_bytes):
         self.log(f"on_hex_edit: {new_bytes}")


### PR DESCRIPTION
- Add key handler for 'a' key in packet list panel
- Generate new packets with Ethernet/IPv4/UDP layers using Scapy
- Calculate timestamp as middle value between current and next packet
- Insert new packet after currently selected packet
- Update all panels (hex, dissection, command) with new packet
- Add status feedback and automatic selection of new packet
- Update help text to show 'a: add packet' instruction